### PR TITLE
Enhance Late Move Reductions (LMR) implementation

### DIFF
--- a/Core/Search/MoveOrdering.cs
+++ b/Core/Search/MoveOrdering.cs
@@ -209,7 +209,7 @@ public sealed class MoveOrdering
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetHistoryScore(Move move)
+    public int GetHistoryScore(Move move)
     {
         return historyTable[(int)move.From, (int)move.To];
     }

--- a/Core/Search/SearchConstants.cs
+++ b/Core/Search/SearchConstants.cs
@@ -51,6 +51,16 @@ public static class SearchConstants
     public const int LMRMinMoves = 4;
     
     /// <summary>
+    ///    Base LMR reduction value.
+    /// </summary>
+    public const double LMRBase = 0.75;
+    
+    /// <summary>
+    ///    LMR logarithmic factor.
+    /// </summary>
+    public const double LMRFactor = 2.25;
+    
+    /// <summary>
     ///    Base futility margin per ply.
     /// </summary>
     public const int FutilityMarginBase = 200;

--- a/Core/Search/SearchEngine.cs
+++ b/Core/Search/SearchEngine.cs
@@ -26,7 +26,7 @@ public class SearchEngine(int ttSizeMB = 128)
       {
          for (int moves = 1; moves < 64; moves++)
          {
-            LMRTable[depth, moves] = (int)(0.75 + Math.Log(depth) * Math.Log(moves) / 2.25);
+            LMRTable[depth, moves] = (int)(SearchConstants.LMRBase + Math.Log(depth) * Math.Log(moves) / SearchConstants.LMRFactor);
          }
       }
       
@@ -531,9 +531,24 @@ public class SearchEngine(int ttSizeMB = 128)
          if (newDepth >= SearchConstants.LMRMinDepth && 
              movesSearched > SearchConstants.LMRMinMoves &&
              !inCheck &&
+             beta - alpha > 1 &&  // Not in PV node
              move is { IsCapture: false, IsPromotion: false })
          {
             reduction = LMRTable[Math.Min(newDepth, 63), Math.Min(movesSearched, 63)];
+            
+            // Reduce less for moves that give check
+            var givesCheck = AttackDetection.IsKingInCheck(in newPosition, newPosition.SideToMove);
+            if (givesCheck)
+               reduction = Math.Max(reduction - 1, 0);
+            
+            // Reduce less for moves with good history
+            var historyScore = moveOrdering.GetHistoryScore(move);
+            if (historyScore > 0)
+               reduction = Math.Max(reduction - 1, 0);
+            else if (historyScore < -5000)
+               reduction += 1;
+            
+            // Ensure we don't reduce too much
             reduction = Math.Min(newDepth - 2, Math.Max(reduction, 1));
          }
          

--- a/Core/Search/SearchThread.cs
+++ b/Core/Search/SearchThread.cs
@@ -39,7 +39,7 @@ public class SearchThread
       {
          for (int moves = 1; moves < 64; moves++)
          {
-            LMRTable[depth, moves] = (int)(0.75 + Math.Log(depth) * Math.Log(moves) / 2.25);
+            LMRTable[depth, moves] = (int)(SearchConstants.LMRBase + Math.Log(depth) * Math.Log(moves) / SearchConstants.LMRFactor);
          }
       }
    }
@@ -442,9 +442,25 @@ public class SearchThread
          // Late move reductions
          if (newDepth >= SearchConstants.LMRMinDepth && 
              movesSearched > SearchConstants.LMRMinMoves &&
-             !inCheck && move is { IsCapture: false, IsPromotion: false })
+             !inCheck &&
+             beta - alpha > 1 &&  // Not in PV node
+             move is { IsCapture: false, IsPromotion: false })
          {
             reduction = LMRTable[Math.Min(newDepth, 63), Math.Min(movesSearched, 63)];
+            
+            // Reduce less for moves that give check
+            var givesCheck = AttackDetection.IsKingInCheck(in newPosition, newPosition.SideToMove);
+            if (givesCheck)
+               reduction = Math.Max(reduction - 1, 0);
+            
+            // Reduce less for moves with good history
+            var historyScore = moveOrdering.GetHistoryScore(move);
+            if (historyScore > 0)
+               reduction = Math.Max(reduction - 1, 0);
+            else if (historyScore < -5000)
+               reduction += 1;
+            
+            // Ensure we don't reduce too much
             reduction = Math.Min(newDepth - 2, Math.Max(reduction, 1));
          }
          


### PR DESCRIPTION
- Add parameterized LMR formula with LMRBase and LMRFactor constants
- Skip LMR in PV nodes for more accurate search
- Reduce less for moves that give check
- Integrate history heuristic: good history reduces less, bad history reduces more
- Make MoveOrdering.GetHistoryScore() public for LMR access
- Ensure consistent implementation across SearchEngine and SearchThread

This improves search efficiency by being more selective about which moves to reduce, maintaining tactical accuracy while pruning more aggressively on likely-bad moves.

🤖 Generated with [Claude Code](https://claude.ai/code)