### PR TITLE
Improve transposition table init

### DIFF
--- a/Meridian/Core/TranspositionTable.cs
+++ b/Meridian/Core/TranspositionTable.cs
@@ -41,7 +41,7 @@ public sealed class TranspositionTable
     public TranspositionTable(int sizeMB = DefaultSizeMB)
     {
         // Calculate number of entries
-        int entrySize = Marshal.SizeOf<TTEntry>();
+        int entrySize = Unsafe.SizeOf<TTEntry>();
         int numEntries = (sizeMB * 1024 * 1024) / entrySize;
         
         // Round down to power of 2 for fast indexing


### PR DESCRIPTION
## Summary
- switch TTEntry size calculation to `Unsafe.SizeOf`

## Testing
- `dotnet build Meridian/Meridian.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684daf1538a0832699cec4e1de8ff333