### PR TITLE
Fix NNUE material tracking

### DIFF
--- a/Meridian/Core/NNUE/PlentyAccumulator.cs
+++ b/Meridian/Core/NNUE/PlentyAccumulator.cs
@@ -22,9 +22,12 @@ public unsafe struct PlentyAccumulator
     
     // Track which ply we're at
     private int _currentPly;
-    
+
     // Material count for output bucket selection
     public int Material { get; private set; }
+
+    // Material stack to restore after unmaking moves
+    private fixed int _materialStack[MaxDepth];
     
     /// <summary>
     /// Initialize accumulator with starting position
@@ -56,6 +59,8 @@ public unsafe struct PlentyAccumulator
         var whiteSlice = whiteFeatures[..numFeatures];
         var blackSlice = blackFeatures[..numFeatures];
         RefreshAccumulator(ref network, whiteSlice, blackSlice, 0, wKingSquare, bKingSquare);
+
+        _materialStack[0] = Material;
     }
     
     /// <summary>
@@ -75,7 +80,8 @@ public unsafe struct PlentyAccumulator
             CopyAccumulator(srcWhite, dstWhite, PlentyNetwork.L1Size);
             CopyAccumulator(srcBlack, dstBlack, PlentyNetwork.L1Size);
         }
-        
+
+        _materialStack[_currentPly + 1] = _materialStack[_currentPly];
         _currentPly++;
     }
     
@@ -85,7 +91,11 @@ public unsafe struct PlentyAccumulator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Pop()
     {
-        if (_currentPly > 0) _currentPly--;
+        if (_currentPly > 0)
+        {
+            _currentPly--;
+            Material = _materialStack[_currentPly];
+        }
     }
     
     /// <summary>
@@ -116,13 +126,12 @@ public unsafe struct PlentyAccumulator
             addedWhite, addedBlack,
             out int numRemoved, out int numAdded);
         
-        // Update material if capturing
-        if (move.IsCapture())
-        {
-            // Recalculate and cache material after capture
-            board.CachedMaterial = board.CalculateMaterial();
-            Material = board.CachedMaterial;
-        }
+        // Compute new material after this move
+        BoardState tmp = board;
+        tmp.MakeMove(move);
+        int newMaterial = tmp.CalculateMaterial();
+        _materialStack[_currentPly] = newMaterial;
+        Material = newMaterial;
         
         // Update both perspectives
         fixed (short* whiteAcc = &_whiteAccumulator[_currentPly * PlentyNetwork.L1Size])
@@ -194,6 +203,8 @@ public unsafe struct PlentyAccumulator
             }
             
         }
+
+        _materialStack[ply] = Material;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Meridian/Core/NNUE/PlentyFeatures.cs
+++ b/Meridian/Core/NNUE/PlentyFeatures.cs
@@ -96,9 +96,19 @@ public static class PlentyFeatures
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetRelativeSquare(int square, Square kingSquare, int kingBucket)
     {
-        // For HalfKA, squares are relative to king position
-        // This is simplified - PlentyChess may have more complex transformations
-        return square;
+        int file = square & 7;
+        int rank = square >> 3;
+
+        int kFile = (int)kingSquare & 7;
+        int kRank = (int)kingSquare >> 3;
+
+        int relFile = file - kFile + 3;
+        int relRank = rank - kRank + 3;
+
+        if ((uint)relFile > 7) relFile = relFile < 0 ? 0 : 7;
+        if ((uint)relRank > 7) relRank = relRank < 0 ? 0 : 7;
+
+        return (relRank << 3) | relFile;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Meridian/Core/NNUE/PlentyNetwork.cs
+++ b/Meridian/Core/NNUE/PlentyNetwork.cs
@@ -328,8 +328,10 @@ public unsafe struct PlentyNetwork
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetOutputBucket(int material)
     {
-        // Simplified output bucket based on material count
-        // In real implementation, this would consider piece types and positions
-        return 0; // Using bucket 0 for now
+        // Map total material value to one of the available buckets
+        int bucket = material / 1000;
+        if (bucket >= OutputBuckets)
+            bucket = OutputBuckets - 1;
+        return bucket;
     }
 }


### PR DESCRIPTION
## Summary
- track material value per ply in `PlentyAccumulator`
- expose material stack when pushing/popping moves
- compute new material in `UpdateAccumulator`
- implement output bucket selection in `PlentyNetwork`
- derive piece square features relative to king position

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e216d123c8326bb951e0c8050c8b8